### PR TITLE
refactor: improve getting-started experience

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,14 @@
+ACCOUNT_CREATOR_KEY=FIXME  # see README, from ~/.near/validator_key.json
+ACCOUNT_RECOVERY_KEY=FIXME # see README, from ~/.near/validator_key.json
+MAIL_HOST=smtp.ethereal.email
+MAIL_PASSWORD=
+MAIL_PORT=587
+MAIL_USER=
+NEW_ACCOUNT_AMOUNT=10000000000000000000000000
+NODE_ENV=development # Node.js environment; either `development` or `production`
+NODE_URL=http://0.0.0.0:3030 # from ~/.near/config.json#rpc.addr – for production, use https://studio.nearprotocol.com/devnet
+PORT=3000 # Used internally by the contract helper; does not have to correspond to the external IP or DNS name and can link to a host machine running the Docker container
+TWILIO_ACCOUNT_SID= # account SID from Twilio (used to send security code)
+TWILIO_AUTH_TOKEN= # auth token from Twilio (used to send security code)
+TWILIO_FROM_PHONE=+14086179592 # phone number from which to send SMS with security code (international format, starting with `+`)
+WALLET_URL=https://wallet.nearprotocol.com

--- a/README.md
+++ b/README.md
@@ -1,55 +1,61 @@
 # near-contract-helper
-Micro-service used to create accounts.
 
-## Environment Variables
-This micro-service depends on the following environment variables:
-* `NODE_URL` -- default `https://studio.nearprotocol.com/devnet`;
-* `PORT` -- default `3000`;
-
-The above variable is used internally by the contract helper, it does not have to correspond to the external IP or DNS
-name and can link to the host machine running the Docker container.
-
-* `NODE_ENV` -- default `production`. Node.js environment (should be `production` for production use, `development` for local development)
-* `NEW_ACCOUNT_AMOUNT` -- default `10000000000`, integer;
-* `ACCOUNT_CREATOR_KEY` -- JSON key of account used to create accounts
-* `ACCOUNT_RECOVERY_KEY` -- JSON key of  account used to recover accounts
-* `TWILIO_FROM_PHONE` – phone number from which to send SMS with security code (international format, starting with `+`)
-* `TWILIO_ACCOUNT_SID` – account SID from Twilio (used to send security code)
-* `TWILIO_AUTH_TOKEN` – auth token from Twilio (used to send security code)
+Microservice used to create NEAR accounts
 
 ## Local Development
 
 ### Requirements
 
-1) Install latest Node.js LTS release.
-2) Install [HTTPie](http://httpie.org/).
+1) Install latest Node.js LTS release
+2) Install [HTTPie](http://httpie.org/)
 
 ### Install dependencies
 
-```
-npm install
-```
+    yarn
 
 ### Create database
 
-Create `accounts_development` Postgres DB with `fiddle` user/password.
+Make sure you have PostgreSQL installed and running. On macOS, you can use [Postgres.app](https://postgresapp.com/).
+
+Create `accounts_development` Postgres DB with `helper` user/password. You can do this from within `psql` using:
+
+    create user helper with superuser password 'helper';
+    create database accounts_development with owner=helper;
+
 After that:
 
-```
-npm run migrate
-```
+    yarn migrate
 
 You can also modify DB config in `config/config.js` to use different connection settings, etc.
 
+### Environment Variables
+
+Create a `.env` file, copy in the default values from `.env.sample`. Read this file for information about how to change configuration settings to suit your needs.
+
+By default, it assumes that you're running a local node and local network. To do this:
+
+* clone [nearcore](https://github.com/nearprotocol/nearcore)
+* in your nearcore directory, get a local network running (at the time of writing, the command was `./scripts/start_localnet.py`)
+
+Note that you need to add a `ACCOUNT_CREATOR_KEY` and `ACCOUNT_RECOVERY_KEY` to your `.env`. Running `nearcore` locally created a `~/.near/validator_keys.json` file for you. Copy the contents of this file and paste them as a single line for each of the `*_KEY` values in your `.env`.
+
 ### Run server
 
-Make sure that before running service there are appropriate env variables set (can be put in  `.env` file in root directory of project):
-
-```
-npm start
-```
+    yarn start
 
 ### Create account
-```
-http post http://localhost:3000/account newAccountId=nosuchuseryet.near newAccountPublicKey=22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV
-```
+
+    http post http://localhost:3000/account newAccountId=nosuchuseryet newAccountPublicKey=22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV
+
+
+## Running tests
+
+### Create database
+
+Follow the instructions above for creating the development database and `helper` user. Then create an `accounts_test` database using `psql`:
+
+    create database accounts_test with owner=helper;
+
+### TODO
+
+How to get the tests running?

--- a/app.js
+++ b/app.js
@@ -36,10 +36,10 @@ const recoveryKeyJson = JSON.parse(process.env.ACCOUNT_RECOVERY_KEY);
 const keyStore = {
     async getKey(networkId, accountId) {
         if (accountId == creatorKeyJson.account_id) {
-            return KeyPair.fromString(creatorKeyJson.private_key);
+            return KeyPair.fromString(creatorKeyJson.secret_key);
         }
         // For account recovery purposes use recovery key when updating any account
-        return KeyPair.fromString(recoveryKeyJson.private_key);
+        return KeyPair.fromString(recoveryKeyJson.secret_key);
     }
 };
 const { connect, KeyPair } = require('nearlib');
@@ -47,7 +47,7 @@ const nearPromise = (async () => {
     const near = await connect({
         deps: { keyStore },
         masterAccount: creatorKeyJson.account_id,
-        nodeUrl: process.env.NODE_URL || 'https://studio.nearprotocol.com/devnet'
+        nodeUrl: process.env.NODE_URL
     });
     return near;
 })();
@@ -56,7 +56,7 @@ app.use(async (ctx, next) => {
     await next();
 });
 
-const NEW_ACCOUNT_AMOUNT = process.env.NEW_ACCOUNT_AMOUNT || 10000000000;
+const NEW_ACCOUNT_AMOUNT = process.env.NEW_ACCOUNT_AMOUNT;
 
 router.post('/account', async ctx => {
     const { newAccountId, newAccountPublicKey } = ctx.request.body;
@@ -66,7 +66,7 @@ router.post('/account', async ctx => {
 
 const password = require('secure-random-password');
 const models = require('./models');
-const FROM_PHONE = process.env.TWILIO_FROM_PHONE || '+14086179592';
+const FROM_PHONE = process.env.TWILIO_FROM_PHONE;
 const SECURITY_CODE_DIGITS = 6;
 
 const sendSms = async ({ to, text }) => {
@@ -151,11 +151,11 @@ const sendMail = async (options) => {
     if (process.env.NODE_ENV == 'production') {
         const nodemailer = require('nodemailer');
         const transport = nodemailer.createTransport({
-            host: process.env.MAIL_HOST || 'smtp.ethereal.email',
-            port: process.env.MAIL_PORT || 587,
+            host: process.env.MAIL_HOST,
+            port: process.env.MAIL_PORT,
             auth: {
-                user: process.env.MAIL_USER || '',
-                pass: process.env.MAIL_PASSWORD || ''
+                user: process.env.MAIL_USER,
+                pass: process.env.MAIL_PASSWORD
             }
         });
         return transport.sendMail({
@@ -167,7 +167,7 @@ const sendMail = async (options) => {
     }
 };
 
-const WALLET_URL = process.env.WALLET_URL ||'https://wallet.nearprotocol.com';
+const WALLET_URL = process.env.WALLET_URL;
 const sendRecoveryMessage = async ({ accountId, phoneNumber, email, seedPhrase }) => {
     const recoverUrl = `${WALLET_URL}/recover-seed-phrase/${encodeURIComponent(accountId)}/${encodeURIComponent(seedPhrase)}`;
     if (phoneNumber) {
@@ -182,7 +182,7 @@ const sendRecoveryMessage = async ({ accountId, phoneNumber, email, seedPhrase }
             text:
 `Hi ${accountId},
 
-This email contains your NEAR account recovery link. 
+This email contains your NEAR account recovery link.
 
 Keep this email safe, and DO NOT SHARE IT! We cannot resend this email.
 
@@ -240,7 +240,7 @@ app
     .use(router.allowedMethods());
 
 if (!module.parent) {
-    app.listen(process.env.PORT || 3000);
+    app.listen(process.env.PORT);
 } else {
     module.exports = app;
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Micro-service used by NEARStudio to deploy smart contracts.",
   "main": "app.js",
   "scripts": {
-    "start": "env $(cat .env) supervisor app",
+    "start": "env $(sed 's/ # .*//' .env) supervisor app",
     "test": "npm run lint && jest test",
     "lint": "eslint .",
     "fix": "eslint . --fix",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5,7 +5,7 @@ const models = require('../models');
 
 const MASTER_KEY_INFO = {
     account_id: 'test.near',
-    private_key: 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw'
+    secret_key: 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw'
 };
 process.env = {
     ...process.env,


### PR DESCRIPTION
This mostly boils down to README improvements, but does introduce one **breaking change**:

* Rather than expecting `CREATOR_KEY` and `RECOVERY_KEY` to have a `private_key` attribute, they are now expected to have a `secret_key`.  This makes it simpler to get started, since `~/.near/validator_key.json` can be copied directly, with no key renames.

Most other noise here comes from the fact that all `.env` settings are now required – this simplifies the code. Many of these were already required but poorly documented; this documents them.

Also interesting: note that the `start` command has changed to use `sed` instead of just `cat`. This is necessary to strip end-of-line comments.  These end-of-line comments provide a much nicer onboarding experience and code-organization/maintenance scheme than placing this information in the README, and are worth the small increase in complexity of the `start` command.

Finally, the expectation established in `.env.sample` is that you will run this codebase connected to a local NEAR network, rather than expecting people to connect to production.