### PR TITLE
refactor: don't show console.error when testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,6 @@ app.use(async function(ctx, next) {
     try {
         await next();
     } catch(e) {
-        console.error('Error: ', e, JSON.stringify(e));
         if (e.response) {
             ctx.throw(e.response.status, e.response.text);
         }
@@ -24,6 +23,7 @@ app.use(async function(ctx, next) {
         }
 
         // TODO: Figure out which errors should be exposed to user
+        console.error('Error: ', e, JSON.stringify(e));
         ctx.throw(400, e.toString());
     }
 });


### PR DESCRIPTION
This `console.error` is only relevant if we're not yet dealing with this error type, so moving it to the bottom of this function is more appropriate.

This also means we no longer have a loud console error when running the tests. This console output made me think the tests weren't working at first!