### PR TITLE
fix: allow null publicKey

### DIFF
--- a/app.js
+++ b/app.js
@@ -263,7 +263,7 @@ const { parseSeedPhrase } = require('near-seed-phrase');
 
 async function withPublicKey(ctx, next) {
     ctx.publicKey = ctx.request.body.publicKey;
-    if (ctx.publicKey) {
+    if (ctx.publicKey !== undefined) {
         await next();
         return;
     }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -314,4 +314,15 @@ describe('/account/deleteRecoveryMethod', () => {
         expect(response.body.length).toBe(1);
         expect(response.body.map(m => m.kind)).toEqual(['email']);
     });
+
+    test('does not return 400 for old accounts with publicKey=NULL', async () => {
+        const accountId = await createNearAccount();
+        const account = await models.Account.create({ accountId });
+        await account.createRecoveryMethod({ kind: 'phrase', publicKey: null });
+        const signature = await signatureFor(accountId);
+
+        let response = await request.post('/account/deleteRecoveryMethod')
+            .send({ accountId, recoveryMethod: 'phrase', publicKey: null, ...signature });
+        expect(response.status).toBe(200);
+    });
 });


### PR DESCRIPTION
Accounts created before we started saving publicKeys will not be able to send them along to these endpoints, so we need to allow them to be null

## to do

- [x] wait until #120 is merged, then retarget this PR at `master`